### PR TITLE
Adds billsim methods and tweaks regex

### DIFF
--- a/src/billsim/constants.py
+++ b/src/billsim/constants.py
@@ -72,7 +72,7 @@ except Exception as err:
 SAVE_ON_COUNT = 1000
 
 BILL_ID_REGEX = r'[a-z]+[1-9][0-9]*-[1-9][0-9]+'
-BILL_NUMBER_PART_REGEX = r'(?P<congress>[1-9][0-9]*)(?P<stage>[a-z]+)(?P<number>[0-9]+)(?P<version>[a-z]+)?'
+BILL_NUMBER_PART_REGEX = r'(?P<congress>[1-9][0-9]*)(?P<stage>[a-z]+)(?P<number>[0-9]+)(?P<version>[a-z]+[0-9]?)?'
 BILL_NUMBER_PART_REGEX_COMPILED = re.compile(BILL_NUMBER_PART_REGEX)
 BILL_NUMBER_REGEX = BILL_NUMBER_PART_REGEX + '$'
 BILL_NUMBER_REGEX_COMPILED = re.compile(BILL_NUMBER_REGEX)

--- a/src/billsim/utils_db.py
+++ b/src/billsim/utils_db.py
@@ -11,7 +11,6 @@ from billsim.utils import getDefaultNamespace, getBillLength, getBillLengthbyPat
 from billsim.database import SessionLocal
 from billsim import pymodels, constants
 
-
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 logging.basicConfig(level='INFO')


### PR DESCRIPTION
To support the flow described in https://github.com/Xcential-Corporation/LoC-billsim-pipeline#proposed-flow, we'll add functions to the billsim lib:

- one to batch save BillToBill objects
- one to batch find Bill IDs from billnumberversion

This PR also suggests a tweak to the billnumberversion regex, which we observed causing a bug in the data processing. If '115hr4743pcs2' is in fact not a valid billnumberversion, it may not be necessary - but it does appear to be contained in the data set.
